### PR TITLE
Add Material style cards and search

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -6,6 +6,7 @@
     <meta name="description" content="{{ site.description }}">
     <title>{{ page.title }} – {{ site.title }}</title>
     <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <header>
@@ -22,5 +23,6 @@
     <footer>
       <p>&copy; {{ site.time | date: "%Y" }}</p>
     </footer>
+    <script src="{{ '/assets/main.js' | relative_url }}"></script>
   </body>
 </html>

--- a/assets/main.css
+++ b/assets/main.css
@@ -84,3 +84,52 @@ article + article {
 .disclaimer {
   margin-bottom: 1em;
 }
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.filters input,
+.filters select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.post-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.post-card {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.post-card .material-icons {
+  font-size: 2rem;
+  margin-right: 1rem;
+  color: #1976d2;
+}
+
+.post-card a {
+  color: #1976d2;
+  text-decoration: none;
+}
+
+.post-card a:hover {
+  text-decoration: underline;
+}
+
+.card-date {
+  color: #666;
+  font-size: 0.875rem;
+  margin: 0;
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,26 @@
+
+document.addEventListener('DOMContentLoaded', function () {
+  var searchInput = document.getElementById('search-input');
+  var yearFilter = document.getElementById('year-filter');
+  var cards = document.querySelectorAll('.post-card');
+
+  function filterPosts() {
+    var searchTerm = searchInput.value.toLowerCase();
+    var yearValue = yearFilter ? yearFilter.value : '';
+    cards.forEach(function(card) {
+      var title = card.getAttribute('data-title').toLowerCase();
+      var year = card.getAttribute('data-year');
+      var matchesSearch = title.indexOf(searchTerm) !== -1;
+      var matchesYear = !yearValue || year === yearValue;
+      if (matchesSearch && matchesYear) {
+        card.style.display = 'flex';
+      } else {
+        card.style.display = 'none';
+      }
+    });
+  }
+
+  if (searchInput) searchInput.addEventListener('input', filterPosts);
+  if (yearFilter) yearFilter.addEventListener('change', filterPosts);
+});
+

--- a/index.md
+++ b/index.md
@@ -7,16 +7,29 @@ title: "My Articles"
   <a href="https://ustinvaskin.github.io/disclaimer-blog/" target="_blank" rel="noopener noreferrer">
     Read the Disclaimer
   </a>
-</p>
+  </p>
 
 Here’s a list of my posts:
 
-<ul class="post-list">
+  <div class="filters">
+  <input type="text" id="search-input" placeholder="Search articles...">
+  {% assign posts_by_year = site.posts | group_by_exp: 'post', 'post.date | date: "%Y"' %}
+  <select id="year-filter">
+    <option value="">All Years</option>
+    {% for group in posts_by_year %}
+    <option value="{{ group.name }}">{{ group.name }}</option>
+    {% endfor %}
+  </select>
+</div>
+
+<div class="post-cards">
   {% for post in site.posts %}
-    <li>
-      <a href="{{ post.url | relative_url }}">
-        {{ post.date | date: "%Y-%m-%d" }} – {{ post.title }}
-      </a>
-    </li>
+    <div class="post-card" data-title="{{ post.title }}" data-year="{{ post.date | date: '%Y' }}">
+      <span class="material-icons">article</span>
+      <div>
+        <p class="card-title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></p>
+        <p class="card-date">{{ post.date | date: "%Y-%m-%d" }}</p>
+      </div>
+    </div>
   {% endfor %}
-</ul>
+</div>


### PR DESCRIPTION
## Summary
- add material icons and attach JS script in default layout
- revamp main page with filters and card layout
- style cards and filters similar to MUI look
- implement search and filter logic in JS

## Testing
- `bundle exec jekyll -v` *(fails: command not found)*
- `bundle install` *(fails due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e322368832591d0be1ba1037726