### PR TITLE
Improve docs and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,39 @@
-# articles
+# Articles
 
-This repository contains the source for my GitHub Pages blog.
+This repository contains the source for my personal blog which is built with [Jekyll](https://jekyllrb.com/). It is served through GitHub Pages at <https://ustinvaskin.github.io/articles>.
+
+## Getting Started
+
+1. Install Ruby along with Bundler.
+2. Install the project dependencies:
+   ```bash
+   bundle install
+   ```
+3. Run the development server:
+   ```bash
+   bundle exec jekyll serve
+   ```
+4. Open your browser to `http://localhost:4000/articles` to view the site.
+
+## Directory Structure
+
+- `_posts/` – Markdown articles organised by date.
+- `_layouts/` – HTML templates used to render the pages.
+- `assets/` – JavaScript and CSS used by the layouts.
+- `docs/` – Additional project documentation.
 
 ## Forms
 
 Both the subscribe and contact forms use [Formspree](https://formspree.io/) to collect submissions. Update the Formspree endpoint URLs in `_layouts/default.htm` with your own form IDs so that messages and email addresses are sent to your account.
+
+## Tests
+
+Basic sanity tests live in the `tests/` directory. They ensure every post contains valid YAML front matter. Run them with:
+
+```bash
+python3 tests/test_posts.py
+```
+
+## Contributing
+
+See the [usage guide](docs/usage.md) for instructions on writing new posts and working with the site locally.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,31 @@
+# Usage Guide
+
+This documentation explains how to work with the blog locally and how to write new articles.
+
+## Local Development
+
+1. Install Ruby and Bundler.
+2. Run `bundle install` to install dependencies.
+3. Start the development server with `bundle exec jekyll serve`.
+4. Visit `http://localhost:4000/articles` in your browser.
+
+## Writing Posts
+
+All posts live in the `_posts` directory and must follow the standard Jekyll filename format: `YEAR-MONTH-DAY-title.md`.
+Each post must contain YAML front matter with at least the following fields:
+
+```
+---
+layout: post
+title: "Your title"
+date:  YYYY-MM-DD HH:MM:SS +0000
+tags:
+  - example
+---
+```
+
+Content goes below the front matter. Use Markdown for formatting.
+
+## Custom Forms
+
+The default layout contains subscribe and contact forms powered by [Formspree](https://formspree.io/). Replace the placeholder Formspree IDs in `_layouts/default.htm` with your own so that submissions are routed to you.

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Simple tests for blog posts.
+
+Checks that each Markdown file in the `_posts` directory contains valid YAML
+front matter with the required fields.
+"""
+from pathlib import Path
+import re
+import sys
+
+REQUIRED_FIELDS = ["layout", "title", "date", "tags"]
+
+def check_frontmatter(path: Path):
+    lines = path.read_text().splitlines()
+    if not lines or lines[0].strip() != "---":
+        return f"{path}: missing starting front matter delimiter"
+    try:
+        end = lines[1:].index("---") + 1
+    except ValueError:
+        return f"{path}: missing closing front matter delimiter"
+    front = "\n".join(lines[1:end])
+    for field in REQUIRED_FIELDS:
+        if not re.search(rf"^{field}:", front, flags=re.MULTILINE):
+            return f"{path}: missing required field '{field}'"
+    return None
+
+def main() -> int:
+    errors = []
+    for post in Path("_posts").glob("*.md"):
+        err = check_frontmatter(post)
+        if err:
+            errors.append(err)
+    if errors:
+        for e in errors:
+            print(e)
+        return 1
+    print("All posts contain required front matter.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- expand README with local dev, directory structure, and test instructions
- add `docs/usage.md` for writing posts and local dev guide
- add `tests/test_posts.py` to validate front matter in posts

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f48567ff4832592bc19cde6d4da63