### PR TITLE
Add dark mode toggle

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -16,6 +16,9 @@
         <a href="{{ '/' | relative_url }}" class="nav-icon" aria-label="Home">
           <span class="material-icons">home</span>
         </a>
+        <button id="theme-toggle" class="nav-icon" aria-label="Toggle dark mode">
+          <span class="material-icons">dark_mode</span>
+        </button>
       </nav>
     </header>
     <div class="wrapper">

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,13 +1,44 @@
+:root {
+  --bg-color: #fdfdfd;
+  --text-color: #000;
+  --header-bg: #1976d2;
+  --header-text: #fff;
+  --link-color: #0366d6;
+  --sidebar-bg: #f4f4f4;
+  --footer-bg: #333;
+  --footer-text: #fff;
+  --card-bg: #fff;
+  --tag-bg: #e0e0e0;
+  --tag-text: #333;
+  --muted-text: #666;
+}
+
 body {
   margin: 0;
   font-family: 'Roboto', Arial, Helvetica, sans-serif;
   line-height: 1.6;
-  background-color: #fdfdfd;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --header-bg: #1e1e1e;
+  --header-text: #eee;
+  --link-color: #90caf9;
+  --sidebar-bg: #1e1e1e;
+  --footer-bg: #111;
+  --footer-text: #eee;
+  --card-bg: #1e1e1e;
+  --tag-bg: #333;
+  --tag-text: #eee;
+  --muted-text: #aaa;
 }
 
 header {
-  background: #1976d2;
-  color: #fff;
+  background: var(--header-bg);
+  color: var(--header-text);
   padding: 1rem;
   margin-bottom: 2rem;
   display: flex;
@@ -28,8 +59,11 @@ header a {
 .nav-icon {
   display: flex;
   align-items: center;
-  color: #fff;
+  color: var(--header-text);
   transition: color 0.2s;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 .nav-icon:hover {
@@ -48,9 +82,13 @@ main {
   flex: 3;
 }
 
+main a {
+  color: var(--link-color);
+}
+
 .sidebar {
   flex: 1;
-  background: #f4f4f4;
+  background: var(--sidebar-bg);
   padding: 1rem;
   border-radius: 4px;
 }
@@ -59,8 +97,8 @@ footer {
   text-align: center;
   margin-top: 2rem;
   padding: 1rem 0;
-  background: #333;
-  color: #fff;
+  background: var(--footer-bg);
+  color: var(--footer-text);
 }
 
 .post-list {
@@ -75,7 +113,7 @@ footer {
 }
 
 .post-list a {
-  color: #0366d6;
+  color: var(--link-color);
   text-decoration: none;
 }
 
@@ -90,7 +128,7 @@ article + article {
 }
 
 .meta {
-  color: #666;
+  color: var(--muted-text);
   font-size: 0.9rem;
   margin-bottom: 1rem;
 }
@@ -122,7 +160,7 @@ article + article {
   display: flex;
   align-items: center;
   padding: 1rem;
-  background: #fff;
+  background: var(--card-bg);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: box-shadow 0.2s, transform 0.2s;
@@ -136,11 +174,11 @@ article + article {
 .post-card .material-icons {
   font-size: 2rem;
   margin-right: 1rem;
-  color: #1976d2;
+  color: var(--link-color);
 }
 
 .post-card a {
-  color: #1976d2;
+  color: var(--link-color);
   text-decoration: none;
 }
 
@@ -149,7 +187,7 @@ article + article {
 }
 
 .card-date {
-  color: #666;
+  color: var(--muted-text);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -161,8 +199,8 @@ article + article {
 
 .tag {
   display: inline-block;
-  background: #e0e0e0;
-  color: #333;
+  background: var(--tag-bg);
+  color: var(--tag-text);
   padding: 0 0.4rem;
   margin-right: 0.25rem;
   border-radius: 4px;
@@ -173,7 +211,7 @@ article + article {
   display: inline-flex;
   align-items: center;
   margin-bottom: 1rem;
-  color: #1976d2;
+  color: var(--link-color);
   text-decoration: none;
   transition: color 0.2s;
 }
@@ -201,7 +239,7 @@ form textarea {
 form input:focus,
 form textarea:focus {
   outline: none;
-  border-color: #1976d2;
+  border-color: var(--link-color);
   box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
 }
 
@@ -210,8 +248,8 @@ form button {
   padding: 0.6rem 1rem;
   border: none;
   border-radius: 6px;
-  background: #1976d2;
-  color: #fff;
+  background: var(--header-bg);
+  color: var(--header-text);
   cursor: pointer;
   font-size: 1rem;
   transition: background 0.2s, transform 0.1s;
@@ -232,7 +270,7 @@ form button:active {
 
 .subscribe,
 .contact {
-  background: #fff;
+  background: var(--card-bg);
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,9 +1,30 @@
 
 document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
   const searchInput = document.getElementById('search-input');
   const yearFilter = document.getElementById('year-filter');
   const tagFilter = document.getElementById('tag-filter');
   const cards = Array.from(document.querySelectorAll('.post-card'));
+
+  const applyTheme = (theme) => {
+    if (theme === 'dark') {
+      document.body.classList.add('dark');
+    } else {
+      document.body.classList.remove('dark');
+    }
+  };
+
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme) {
+    applyTheme(savedTheme);
+  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    applyTheme('dark');
+  }
+
+  toggle?.addEventListener('click', () => {
+    const dark = document.body.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  });
 
   const populateTagFilter = () => {
     if (!tagFilter || tagFilter.children.length > 1) return;


### PR DESCRIPTION
## Summary
- style updates: add color variables and dark theme overrides
- add dark mode toggle button in header
- switch theme client-side and persist preference

## Testing
- `python3 tests/test_posts.py`


------
https://chatgpt.com/codex/tasks/task_e_683f4afd46688325aca3715413c60ae1