### PR TITLE
Improve code block styling

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -11,6 +11,9 @@
   --tag-bg: #e0e0e0;
   --tag-text: #333;
   --muted-text: #666;
+  --code-bg: #f6f8fa;
+  --code-border: #ddd;
+  --code-font: 'Source Code Pro', monospace;
 }
 
 body {
@@ -34,6 +37,9 @@ body.dark {
   --tag-bg: #333;
   --tag-text: #eee;
   --muted-text: #aaa;
+  --code-bg: #1e1e1e;
+  --code-border: #333;
+  --code-font: 'Source Code Pro', monospace;
 }
 
 header {
@@ -280,4 +286,30 @@ form button:active {
 .subscribe h3,
 .contact h3 {
   margin-top: 0;
+}
+
+pre {
+  background: var(--code-bg);
+  padding: 1rem;
+  border: 1px solid var(--code-border);
+  border-radius: 6px;
+  overflow-x: auto;
+  font-family: var(--code-font);
+}
+
+.code-card {
+  background: var(--card-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  margin: 1rem 0;
+  padding: 1rem;
+}
+
+.code-card pre {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--code-font);
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,3 +31,15 @@ Content goes below the front matter. Use Markdown for formatting.
 ## Custom Forms
 
 The default layout contains subscribe and contact forms powered by [Formspree](https://formspree.io/). Replace the placeholder Formspree IDs in `_layouts/default.htm` with your own so that submissions are routed to you.
+
+## Code Cards
+
+Use code cards to highlight important examples in posts. Add the class after a fenced code block to apply the styling:
+
+
+```js
+console.log("hello");
+```
+{: .code-card}
+
+This will render the block inside a styled card.


### PR DESCRIPTION
## Summary
- add CSS variables and styles for code blocks and code cards
- document how to use code cards in the usage guide

## Testing
- `python3 tests/test_posts.py`
- `bundle exec jekyll build` *(fails: bundler not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f1d8eb4832598b970a9617784a5