### PR TITLE
Improve header navigation

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -62,17 +62,28 @@ header a {
   text-decoration: none;
 }
 
+header nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .nav-icon {
   display: flex;
   align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
   color: var(--header-text);
-  transition: color 0.2s;
+  transition: background 0.2s, color 0.2s;
   background: none;
   border: none;
+  border-radius: 50%;
   cursor: pointer;
 }
 
 .nav-icon:hover {
+  background: rgba(255, 255, 255, 0.2);
   color: #bbdefb;
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -6,6 +6,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const tagFilter = document.getElementById('tag-filter');
   const cards = Array.from(document.querySelectorAll('.post-card'));
 
+  const updateToggleIcon = () => {
+    if (!toggle) return;
+    const icon = toggle.querySelector('.material-icons');
+    if (!icon) return;
+    icon.textContent = document.body.classList.contains('dark')
+      ? 'light_mode'
+      : 'dark_mode';
+  };
+
   const applyTheme = (theme) => {
     if (theme === 'dark') {
       document.body.classList.add('dark');
@@ -20,10 +29,12 @@ document.addEventListener('DOMContentLoaded', () => {
   } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
     applyTheme('dark');
   }
+  updateToggleIcon();
 
   toggle?.addEventListener('click', () => {
     const dark = document.body.classList.toggle('dark');
     localStorage.setItem('theme', dark ? 'dark' : 'light');
+    updateToggleIcon();
   });
 
   const populateTagFilter = () => {


### PR DESCRIPTION
## Summary
- modernize the nav icons
- update the dark mode toggle so the icon switches

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f50624d74832589a8d7400269bb17