### PR TITLE
Enable code highlighting with copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This repository contains the source for my personal blog which is built with [Je
 - `assets/` – JavaScript and CSS used by the layouts.
 - `docs/` – Additional project documentation.
 
+## Syntax Highlighting
+
+Code blocks use [highlight.js](https://highlightjs.org/) for styling. Each block
+includes a small "Copy" button to quickly copy the snippet to your clipboard.
+
 ## Forms
 
 Both the subscribe and contact forms use [Formspree](https://formspree.io/) to collect submissions. Update the Formspree endpoint URLs in `_layouts/default.htm` with your own form IDs so that messages and email addresses are sent to your account.

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,7 @@ url:         "https://ustinvaskin.github.io"   # NO angle brackets!
 theme:       minima
 plugins:
   - jekyll-feed
+highlighter: none
+kramdown:
+  syntax_highlighter_opts:
+    disable: true

--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
   </head>
   <body>
     <header>

--- a/assets/main.css
+++ b/assets/main.css
@@ -292,3 +292,27 @@ form button:active {
 .contact h3 {
   margin-top: 0;
 }
+
+pre {
+  background: #f6f8fa;
+  padding: 1rem;
+  overflow: auto;
+  border-radius: 6px;
+}
+
+body.dark pre {
+  background: #1e1e1e;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  background: var(--header-bg);
+  color: var(--header-text);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -83,5 +83,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
   filterPosts();
 
+  document.querySelectorAll('pre code').forEach(block => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-btn';
+    button.textContent = 'Copy';
+    button.addEventListener('click', () => {
+      navigator.clipboard.writeText(block.innerText).then(() => {
+        button.textContent = 'Copied!';
+        setTimeout(() => (button.textContent = 'Copy'), 2000);
+      });
+    });
+    const pre = block.parentElement;
+    if (pre && pre.tagName === 'PRE') {
+      pre.style.position = 'relative';
+      pre.appendChild(button);
+    }
+  });
+
+  if (window.hljs) {
+    hljs.highlightAll();
+  }
+
 });
 


### PR DESCRIPTION
## Summary
- add highlight.js via CDN and disable rouge
- add copy button behavior for code blocks
- style code blocks and copy button
- document syntax highlighting feature

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5332b2d0832580e2dcc2ca523384