### PR TITLE
Move disclaimer link to footer

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -51,6 +51,9 @@
     </div>
     <footer>
       <p>&copy; {{ site.time | date: "%Y" }}</p>
+      <p class="disclaimer">
+        <a href="https://ustinvaskin.github.io/disclaimer-blog/" target="_blank" rel="noopener noreferrer">Read the Disclaimer</a>
+      </p>
     </footer>
     <script src="{{ '/assets/main.js' | relative_url }}" defer></script>
   </body>

--- a/assets/main.css
+++ b/assets/main.css
@@ -145,7 +145,9 @@ article + article {
 }
 
 .disclaimer {
-  margin-bottom: 1em;
+  margin: 0.5em 0;
+  font-size: 0.9rem;
+  color: var(--muted-text);
 }
 
 .filters {

--- a/index.md
+++ b/index.md
@@ -3,11 +3,6 @@ layout: default
 title: "My Articles"
 ---
 
-<p class="disclaimer">
-  <a href="https://ustinvaskin.github.io/disclaimer-blog/" target="_blank" rel="noopener noreferrer">
-    Read the Disclaimer
-  </a>
-  </p>
 
 Here’s a list of my posts:
 


### PR DESCRIPTION
## Summary
- move disclaimers link from the top of the index page into the site footer
- restyle the disclaimer as muted small text

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5428c6708325bd0aec1e3defa49e