### PR TITLE
Fix highlight.js theme for dark mode

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -8,7 +8,8 @@
     <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css">
+    <link id="hljs-theme-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css">
+    <link id="hljs-theme-dark" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css" disabled>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
   </head>
   <body>

--- a/assets/main.js
+++ b/assets/main.js
@@ -15,11 +15,18 @@ document.addEventListener('DOMContentLoaded', () => {
       : 'dark_mode';
   };
 
+  const hljsLight = document.getElementById('hljs-theme-light');
+  const hljsDark = document.getElementById('hljs-theme-dark');
+
   const applyTheme = (theme) => {
     if (theme === 'dark') {
       document.body.classList.add('dark');
+      if (hljsLight) hljsLight.disabled = true;
+      if (hljsDark) hljsDark.disabled = false;
     } else {
       document.body.classList.remove('dark');
+      if (hljsLight) hljsLight.disabled = false;
+      if (hljsDark) hljsDark.disabled = true;
     }
   };
 


### PR DESCRIPTION
## Summary
- toggle highlight.js light/dark styles when switching site theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f573251e483258c1c182db7b3f7d3