### PR TITLE
Improve form accessibility

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -34,19 +34,23 @@
         <div class="subscribe">
           <h3>Subscribe</h3>
           <form id="subscribe-form" action="https://formspree.io/f/xldnekqn" method="POST">
-            <input type="email" name="email" id="subscribe-email" placeholder="Your email" required>
+            <label for="subscribe-email">Email address</label>
+            <input type="email" name="email" id="subscribe-email" placeholder="Your email" aria-describedby="subscribe-message" required>
             <button type="submit">Subscribe</button>
           </form>
-          <p id="subscribe-message" class="hidden"></p>
+          <p id="subscribe-message" class="form-message hidden" aria-live="polite"></p>
         </div>
 
         <div class="contact">
           <h3>Contact Me</h3>
           <form class="contact-form" action="https://formspree.io/f/xldnekqn" method="POST">
-            <input type="email" name="email" placeholder="Your email" required>
-            <textarea name="message" rows="4" placeholder="Your message" required></textarea>
+            <label for="contact-email">Email address</label>
+            <input type="email" id="contact-email" name="email" placeholder="Your email" aria-describedby="contact-form-message" required>
+            <label for="contact-text">Message</label>
+            <textarea id="contact-text" name="message" rows="4" placeholder="Your message" aria-describedby="contact-form-message" required></textarea>
             <button type="submit">Send Message</button>
           </form>
+          <p id="contact-form-message" class="form-message hidden" aria-live="polite"></p>
         </div>
       </aside>
     </div>

--- a/assets/main.css
+++ b/assets/main.css
@@ -272,6 +272,10 @@ form {
   margin-bottom: 1rem;
 }
 
+form label {
+  font-weight: 500;
+}
+
 form input,
 form textarea {
   padding: 0.75rem;
@@ -280,7 +284,19 @@ form textarea {
   font: inherit;
   width: 100%;
   box-sizing: border-box;
+  background: var(--card-bg);
+  color: var(--text-color);
   transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+form input.error,
+form textarea.error {
+  border-color: #e53935;
+}
+
+body.dark form input.error,
+body.dark form textarea.error {
+  border-color: #ef9a9a;
 }
 
 form input:focus,
@@ -318,6 +334,21 @@ form button:active {
 
 .hidden {
   display: none;
+}
+
+.form-message {
+  font-size: 0.875rem;
+  margin-top: -0.25rem;
+  margin-bottom: 0.25rem;
+  color: var(--muted-text);
+}
+
+.form-message.error {
+  color: #e53935;
+}
+
+body.dark .form-message.error {
+  color: #ef9a9a;
 }
 
 .subscribe,

--- a/assets/main.js
+++ b/assets/main.js
@@ -108,6 +108,48 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  const handleForm = (form, messageEl) => {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      messageEl.classList.add('hidden');
+      form.querySelectorAll('.error').forEach(el => el.classList.remove('error'));
+
+      if (!form.checkValidity()) {
+        form.reportValidity();
+        return;
+      }
+
+      const data = new FormData(form);
+      try {
+        const resp = await fetch(form.action, {
+          method: 'POST',
+          body: data,
+          headers: { 'Accept': 'application/json' }
+        });
+        if (resp.ok) {
+          form.reset();
+          messageEl.textContent = 'Thanks! Your submission has been received.';
+        } else {
+          messageEl.textContent = 'There was a problem submitting the form.';
+          const inputs = form.querySelectorAll('input, textarea');
+          inputs.forEach(i => i.classList.add('error'));
+        }
+      } catch {
+        messageEl.textContent = 'There was a problem submitting the form.';
+      }
+
+      messageEl.classList.remove('hidden');
+    });
+  };
+
+  const subscribeForm = document.getElementById('subscribe-form');
+  const subscribeMsg = document.getElementById('subscribe-message');
+  if (subscribeForm && subscribeMsg) handleForm(subscribeForm, subscribeMsg);
+
+  const contactForm = document.querySelector('.contact-form');
+  const contactMsg = document.getElementById('contact-form-message');
+  if (contactForm && contactMsg) handleForm(contactForm, contactMsg);
+
   if (window.hljs) {
     hljs.highlightAll();
   }


### PR DESCRIPTION
## Summary
- add labels and error feedback for sidebar forms
- tweak form control styling for both themes
- add JS helpers to submit forms via fetch

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5d6333588325a232693c1d087665