### PR TITLE
Add optional Markdown and HTML linting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Basic sanity tests live in the `tests/` directory. They ensure every post contai
 python3 tests/test_posts.py
 ```
 
+For additional checks consider using tools such as
+[`markdownlint`](https://github.com/markdownlint/markdownlint) to enforce
+consistent Markdown style and
+[`htmlproofer`](https://github.com/gjtorikian/html-proofer) to detect broken
+links or invalid HTML before publishing. These tools can be run locally or
+integrated into continuous integration workflows.
+
 ## Contributing
 
 See the [usage guide](docs/usage.md) for instructions on writing new posts and working with the site locally.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,3 +31,19 @@ Content goes below the front matter. Use Markdown for formatting.
 ## Custom Forms
 
 The default layout contains subscribe and contact forms powered by [Formspree](https://formspree.io/). Replace the placeholder Formspree IDs in `_layouts/default.htm` with your own so that submissions are routed to you.
+
+## Quality Checks
+
+Before publishing a post you can run the Python tests to validate front matter,
+links and HTML:
+
+```bash
+python3 tests/test_posts.py
+```
+
+Additional tools such as
+[markdownlint](https://github.com/markdownlint/markdownlint) help ensure a
+consistent Markdown style, while
+[htmlproofer](https://github.com/gjtorikian/html-proofer) checks for broken links
+and malformed HTML. Integrating these checks into your workflow will help keep
+the blog error free.


### PR DESCRIPTION
## Summary
- mention `markdownlint` and `htmlproofer` in the README tests section
- add a Quality Checks section in `docs/usage.md`

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5e213e748325984cc35f6d69edef