### PR TITLE
Add CI workflow for checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - run: bundle install --jobs 4 --retry 3
+      - run: ./scripts/check.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
+
+# Development helpers
+gem "mdl", group: :development
+gem "html-proofer", group: :development

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Basic sanity tests live in the `tests/` directory. They ensure every post contai
 python3 tests/test_posts.py
 ```
 
+For additional checks the development environment includes
+[`markdownlint`](https://github.com/markdownlint/markdownlint) and
+[`html-proofer`](https://github.com/gjtorikian/html-proofer). Run them with:
+
+```bash
+bundle exec mdl .
+bundle exec htmlproofer ./_site --disable-external
+```
+
+`htmlproofer` expects the site to be built first with `bundle exec jekyll build`.
+These tools can be run locally or integrated into continuous integration
+workflows. A helper script at `scripts/check.sh` runs all checks in one go and
+is executed automatically by the GitHub Actions workflow defined in
+`.github/workflows/ci.yml`.
+
 ## Contributing
 
 See the [usage guide](docs/usage.md) for instructions on writing new posts and working with the site locally.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,3 +31,27 @@ Content goes below the front matter. Use Markdown for formatting.
 ## Custom Forms
 
 The default layout contains subscribe and contact forms powered by [Formspree](https://formspree.io/). Replace the placeholder Formspree IDs in `_layouts/default.htm` with your own so that submissions are routed to you.
+
+## Quality Checks
+
+Before publishing a post you can run the Python tests to validate front matter,
+links and HTML:
+
+```bash
+python3 tests/test_posts.py
+```
+
+Additional tools are available via Bundler:
+
+```bash
+bundle exec mdl .
+bundle exec jekyll build
+bundle exec htmlproofer ./_site --disable-external
+```
+
+`markdownlint` enforces a consistent Markdown style and `htmlproofer` catches
+broken links or malformed HTML. Integrating these checks into your workflow will
+help keep the blog error free.
+You can also run `scripts/check.sh` to execute all of the above commands at once.
+The same script is triggered in CI via the GitHub Actions workflow in
+`.github/workflows/ci.yml`.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Run basic quality checks
+
+python3 tests/test_posts.py || exit 1
+bundle exec mdl . || exit 1
+bundle exec jekyll build -d /tmp/site >/dev/null || exit 1
+bundle exec htmlproofer /tmp/site --disable-external || exit 1
+rm -rf /tmp/site
+


### PR DESCRIPTION
## Summary
- run `scripts/check.sh` in GitHub Actions to test and lint
- mention the new CI workflow in README and usage docs

## Testing
- `python3 tests/test_posts.py`
- `bundle install` *(fails: 403 Forbidden)*
- `./scripts/check.sh` *(fails: command not found: mdl)*


------
https://chatgpt.com/codex/tasks/task_e_683f5e213e748325984cc35f6d69edef