### PR TITLE
Fix mobile header layout

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -421,12 +421,13 @@ body.dark .hljs-comment {
 
 @media (max-width: 768px) {
   header {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 
   header nav {
-    margin-top: 0.5rem;
+    margin-top: 0;
   }
 
   .wrapper {


### PR DESCRIPTION
## Summary
- keep mobile header items on one row

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f64390fd083258a8ff005b93a63c2