### PR TITLE
Add quirky page loader

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -13,6 +13,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
   </head>
   <body>
+    <div id="loading-screen">
+      <div class="spinner"></div>
+      <p>Loading the good stuff...</p>
+    </div>
     <header>
       <h1><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
       <nav>

--- a/assets/main.css
+++ b/assets/main.css
@@ -452,3 +452,35 @@ body.dark .hljs-comment {
     margin-bottom: 0.5rem;
   }
 }
+
+#loading-screen {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  transition: opacity 0.5s ease;
+}
+
+#loading-screen.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+#loading-screen .spinner {
+  width: 3rem;
+  height: 3rem;
+  border: 0.5rem solid var(--border-color);
+  border-top-color: var(--header-bg);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -154,5 +154,10 @@ document.addEventListener('DOMContentLoaded', () => {
     hljs.highlightAll();
   }
 
+  const loader = document.getElementById('loading-screen');
+  if (loader) {
+    setTimeout(() => loader.classList.add('hidden'), 300);
+  }
+
 });
 


### PR DESCRIPTION
## Summary
- embed a loading overlay in the default layout
- style the loader with fun animation
- hide the loader after the page finishes loading

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6ad855ec8325a278a13c837826d8