### PR TITLE
Improve loader behavior

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -156,7 +156,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const loader = document.getElementById('loading-screen');
   if (loader) {
-    setTimeout(() => loader.classList.add('hidden'), 300);
+    const alreadyShown = localStorage.getItem('loaderShown');
+    if (alreadyShown) {
+      loader.classList.add('hidden');
+    } else {
+      setTimeout(() => {
+        loader.classList.add('hidden');
+        localStorage.setItem('loaderShown', 'true');
+      }, 300);
+    }
   }
 
 });


### PR DESCRIPTION
## Summary
- update JS to only display loader on the first visit

## Testing
- `python tests/test_posts.py`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c4e22908325b12cf9d7a6ead551