### PR TITLE
Add tag counts and clear filters

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -194,6 +194,14 @@ article + article {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+.filters button {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--header-bg);
+  color: var(--header-text);
+  cursor: pointer;
+}
 
 .post-cards {
   display: flex;

--- a/assets/main.js
+++ b/assets/main.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('search-input');
   const yearFilter = document.getElementById('year-filter');
   const tagFilter = document.getElementById('tag-filter');
+  const clearBtn = document.getElementById('clear-filters');
   const cards = Array.from(document.querySelectorAll('.post-card'));
 
   const updateToggleIcon = () => {
@@ -85,6 +86,12 @@ document.addEventListener('DOMContentLoaded', () => {
   searchInput?.addEventListener('input', filterPosts);
   yearFilter?.addEventListener('change', filterPosts);
   tagFilter?.addEventListener('change', filterPosts);
+  clearBtn?.addEventListener('click', () => {
+    if (searchInput) searchInput.value = '';
+    if (yearFilter) yearFilter.value = '';
+    if (tagFilter) tagFilter.value = '';
+    filterPosts();
+  });
 
   populateTagFilter();
 

--- a/index.md
+++ b/index.md
@@ -15,13 +15,14 @@ Here’s a list of my posts:
     <option value="{{ group.name }}">{{ group.name }}</option>
     {% endfor %}
   </select>
-  {% assign all_tags = site.tags | map: 'first' | sort %}
+  {% assign tags_sorted = site.tags | sort %}
   <select id="tag-filter">
     <option value="">All Tags</option>
-    {% for tag in all_tags %}
-    <option value="{{ tag }}">{{ tag }}</option>
+    {% for tag in tags_sorted %}
+    <option value="{{ tag[0] }}">{{ tag[0] }} ({{ tag[1].size }})</option>
     {% endfor %}
   </select>
+  <button id="clear-filters" type="button">Clear Filters</button>
 </div>
 
 <div class="post-cards">


### PR DESCRIPTION
## Summary
- improve blog index filters by showing tag counts
- add a clear filters button and handle reset in JS
- style the new button

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6cbd12c88325a8f9c12aaa991828