### PR TITLE
Add sidebar sections and analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,3 +16,4 @@ highlighter: none
 kramdown:
   syntax_highlighter_opts:
     disable: true
+analytics_id: "" # Google Analytics measurement ID

--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -52,6 +52,25 @@
           </form>
           <p id="contact-form-message" class="form-message hidden" aria-live="polite"></p>
         </div>
+
+        <div class="recent-posts">
+          <h3>Recent Posts</h3>
+          <ul class="post-list">
+            {% for post in site.posts limit:5 %}
+            <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+
+        <div class="popular-tags">
+          <h3>Popular Tags</h3>
+          <ul class="tag-list">
+            {% assign tags_sorted = site.tags | sort: 'last' %}
+            {% for tag in tags_sorted reversed limit:5 %}
+            <li><span class="tag">{{ tag[0] }}</span> ({{ tag[1].size }})</li>
+            {% endfor %}
+          </ul>
+        </div>
       </aside>
     </div>
     <footer>
@@ -61,5 +80,14 @@
       </p>
     </footer>
     <script src="{{ '/assets/main.js' | relative_url }}" defer></script>
+    {% if site.analytics_id %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics_id }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ site.analytics_id }}');
+    </script>
+    {% endif %}
   </body>
 </html>

--- a/assets/main.css
+++ b/assets/main.css
@@ -3,6 +3,7 @@
   --bg-color: #f2f2f5;
   --text-color: #000;
   --header-bg: #5a23d7;
+  --header-bg2: #3720a3;
   --header-text: #fff;
   --link-color: #5a23d7;
   --sidebar-bg: #fff;
@@ -27,6 +28,7 @@ body.dark {
   --bg-color: #121212;
   --text-color: #e0e0e0;
   --header-bg: #3720a3;
+  --header-bg2: #5a23d7;
   --header-text: #eee;
   --link-color: #a78fff;
   --sidebar-bg: #1c1c1c;
@@ -40,7 +42,7 @@ body.dark {
 }
 
 header {
-  background: var(--header-bg);
+  background: linear-gradient(90deg, var(--header-bg), var(--header-bg2));
   color: var(--header-text);
   padding: 1.5rem 1rem;
   margin-bottom: 2rem;
@@ -162,6 +164,27 @@ footer {
   text-decoration: underline;
   outline: 2px solid var(--link-color);
   outline-offset: 2px;
+}
+
+.tag-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tag-list li {
+  margin: 0.25rem 0;
+}
+
+.tag-list a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.tag-list a:hover,
+.tag-list a:focus {
+  text-decoration: underline;
+  outline: none;
 }
 
 article + article {
@@ -360,7 +383,9 @@ body.dark .form-message.error {
 }
 
 .subscribe,
-.contact {
+.contact,
+.recent-posts,
+.popular-tags {
   background: var(--card-bg);
   padding: 1rem;
   border-radius: 8px;
@@ -370,7 +395,9 @@ body.dark .form-message.error {
 }
 
 .subscribe h3,
-.contact h3 {
+.contact h3,
+.recent-posts h3,
+.popular-tags h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- style header with gradient
- style recent posts and popular tags blocks
- add recent posts and popular tags sidebar sections
- integrate optional Google Analytics

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6e3bbe108325a154532ad78a4d40