### PR TITLE
Fix filter layout on mobile

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -479,14 +479,15 @@ body.dark .hljs-comment {
   }
 
   .filters {
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
   }
 
   .filters input,
   .filters select,
   .filters button {
-    width: 100%;
+    flex: 1 1 160px;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep filter bar horizontal on mobile screens

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f724214f483259929eef12df975d4