### PR TITLE
Improve input styling for dark mode

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -215,9 +215,16 @@ article + article {
 .filters input,
 .filters select {
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   flex: 1 1 160px;
+  background: var(--card-bg);
+  color: var(--text-color);
+}
+
+.filters select option {
+  background: var(--card-bg);
+  color: var(--text-color);
 }
 .filters button {
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## Summary
- use CSS variables for filter input borders
- style select backgrounds and option elements

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f72e667bc8325b5bbf676a79e0417