### PR TITLE
Fix dark mode styling for filter controls

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -220,6 +220,8 @@ article + article {
   flex: 1 1 160px;
   background: var(--card-bg);
   color: var(--text-color);
+  height: 2.5rem;
+  box-sizing: border-box;
 }
 
 .filters select option {
@@ -234,6 +236,9 @@ article + article {
   color: var(--header-text);
   cursor: pointer;
   white-space: nowrap;
+  flex: 1 1 160px;
+  height: 2.5rem;
+  box-sizing: border-box;
 }
 
 .post-cards {


### PR DESCRIPTION
## Summary
- adjust filter control styles so search, select, and button share consistent height and width
- keep controls dark-themed by using CSS variables

## Testing
- `python tests/test_posts.py`


------
https://chatgpt.com/codex/tasks/task_e_683f74232940832596f29a42ebf59f92