### PR TITLE
Add no posts alert

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -382,6 +382,21 @@ form button:active {
   display: none;
 }
 
+.info-alert {
+  padding: 0.75rem 1rem;
+  border: 1px solid #90caf9;
+  background: #e8f4fd;
+  color: #0d47a1;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+body.dark .info-alert {
+  background: #0d47a1;
+  color: #e8f4fd;
+  border-color: #42a5f5;
+}
+
 .form-message {
   font-size: 0.875rem;
   margin-top: -0.25rem;

--- a/assets/main.js
+++ b/assets/main.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const tagFilter = document.getElementById('tag-filter');
   const clearBtn = document.getElementById('clear-filters');
   const cards = Array.from(document.querySelectorAll('.post-card'));
+  const noPostsMessage = document.getElementById('no-posts-message');
 
   const updateToggleIcon = () => {
     if (!toggle) return;
@@ -80,6 +81,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const matchesTag = !tagValue || tags.includes(tagValue);
 
       card.style.display = matchesSearch && matchesYear && matchesTag ? 'flex' : 'none';
+    }
+
+    const anyVisible = cards.some(card => card.style.display !== 'none');
+    if (noPostsMessage) {
+      noPostsMessage.style.display = anyVisible ? 'none' : 'block';
     }
   };
 

--- a/index.md
+++ b/index.md
@@ -25,6 +25,8 @@ Here’s a list of my posts:
   <button id="clear-filters" type="button">Clear Filters</button>
 </div>
 
+<div id="no-posts-message" class="info-alert hidden" role="alert">No posts found.</div>
+
 <div class="post-cards">
   {% for post in site.posts %}
     <div class="post-card" data-title="{{ post.title }}" data-year="{{ post.date | date: '%Y' }}" data-tags="{{ post.tags | join: ',' }}">


### PR DESCRIPTION
## Summary
- show an informational alert if search or filters return no posts
- style the alert for both themes

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f761a6590832581dadb9db3e00c70