### PR TITLE
Improve dark mode colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Both the subscribe and contact forms rely on [Formspree](https://formspree.io/) 
 ## Dark Mode
 
 A dark colour scheme is built in. Click the moon icon in the header to toggle between light and dark styles. Your preference is stored in `localStorage` and highlight.js loads the matching theme.
-The site colours are defined at the top of `assets/main.css`, with overrides in `body.dark` for the dark theme.
+The site colours are defined at the top of `assets/main.css`, with overrides in `body.dark` for the dark theme. The palette now uses deep greys with soft blue accents for improved readability.
 
 ## Tests
 

--- a/assets/main.css
+++ b/assets/main.css
@@ -25,20 +25,20 @@ body {
 }
 
 body.dark {
-  --bg-color: #121212;
-  --text-color: #e0e0e0;
-  --header-bg: #2196f3;
-  --header-bg2: #1976d2;
-  --header-text: #eee;
-  --link-color: #90caf9;
-  --sidebar-bg: #1e1e1e;
-  --footer-bg: #1e1e1e;
-  --footer-text: #e0e0e0;
-  --card-bg: #1e1e1e;
-  --border-color: #333;
-  --tag-bg: #1565c0;
-  --tag-text: #e0e0e0;
-  --muted-text: #ccc;
+  --bg-color: #0d1117;
+  --text-color: #c9d1d9;
+  --header-bg: #21262d;
+  --header-bg2: #2d333b;
+  --header-text: #f0f6fc;
+  --link-color: #58a6ff;
+  --sidebar-bg: #161b22;
+  --footer-bg: #161b22;
+  --footer-text: #8b949e;
+  --card-bg: #161b22;
+  --border-color: #30363d;
+  --tag-bg: #238636;
+  --tag-text: #c9d1d9;
+  --muted-text: #8b949e;
 }
 
 header {


### PR DESCRIPTION
## Summary
- tweak dark mode palette in `assets/main.css`
- mention new palette in README

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7afe67a48325accf7ce85eb8804a