### PR TITLE
Improve perceived load time

### DIFF
--- a/_layouts/default.htm
+++ b/_layouts/default.htm
@@ -7,10 +7,13 @@
     <title>{{ page.title }} – {{ site.title }}</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preload" href="{{ '/assets/main.css' | relative_url }}" as="style">
     <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" as="style" crossorigin>
     <link id="hljs-theme-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css" as="style" crossorigin>
     <link id="hljs-theme-dark" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css" disabled>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js" defer></script>
   </head>

--- a/assets/main.js
+++ b/assets/main.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const yearFilter = document.getElementById('year-filter');
   const tagFilter = document.getElementById('tag-filter');
   const clearBtn = document.getElementById('clear-filters');
+  document.querySelectorAll('img').forEach(img => {
+    if (!img.loading) img.loading = 'lazy';
+  });
   const cards = Array.from(document.querySelectorAll('.post-card'));
   const cardData = cards.map(card => ({
     el: card,


### PR DESCRIPTION
## Summary
- preload CSS and fonts for faster FCP/LCP
- lazy load images via JS

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_683f82d8962083258282f437d85b7b64