### PR TITLE
Add helper script and improve index filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ python3 tests/test_posts.py
 
 ## Contributing
 
-See the [usage guide](docs/usage.md) for instructions on writing new posts and working with the site locally.
+See the [usage guide](docs/usage.md) for detailed steps on writing new posts and working with the site locally. Use `scripts/new_post.py` to quickly generate a new post with the required front matter.

--- a/assets/main.css
+++ b/assets/main.css
@@ -186,6 +186,7 @@ article + article {
   display: flex;
   gap: 1rem;
   margin-bottom: 1rem;
+  flex-wrap: wrap;
 }
 
 .filters input,
@@ -193,6 +194,12 @@ article + article {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+.no-posts {
+  text-align: center;
+  font-style: italic;
+  color: var(--muted-text);
 }
 
 .post-cards {

--- a/assets/main.js
+++ b/assets/main.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('search-input');
   const yearFilter = document.getElementById('year-filter');
   const tagFilter = document.getElementById('tag-filter');
+  const noPosts = document.getElementById('no-posts');
   const cards = Array.from(document.querySelectorAll('.post-card'));
 
   const updateToggleIcon = () => {
@@ -69,6 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const yearValue = yearFilter?.value ?? '';
     const tagValue = tagFilter?.value ?? '';
 
+    let visible = 0;
     for (const card of cards) {
       const title = card.dataset.title.toLowerCase();
       const year = card.dataset.year;
@@ -78,7 +80,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const matchesYear = !yearValue || year === yearValue;
       const matchesTag = !tagValue || tags.includes(tagValue);
 
-      card.style.display = matchesSearch && matchesYear && matchesTag ? 'flex' : 'none';
+      const show = matchesSearch && matchesYear && matchesTag;
+      card.style.display = show ? 'flex' : 'none';
+      if (show) visible++;
+    }
+    if (noPosts) {
+      noPosts.classList.toggle('hidden', visible !== 0);
     }
   };
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,3 +41,12 @@ links and HTML:
 python3 tests/test_posts.py
 ```
 
+
+## Publishing Workflow
+
+1. Run `scripts/new_post.py` and follow the prompts to create a new Markdown file in `_posts/` with the required front matter.
+2. Write your post content below the generated front matter.
+3. Preview the site locally with `bundle exec jekyll serve`.
+4. Run `python3 tests/test_posts.py` to ensure the post passes validation.
+5. Commit your changes and push them to GitHub.
+

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ Here’s a list of my posts:
     <option value="">All Tags</option>
     {% for tag in all_tags %}
     <option value="{{ tag }}">{{ tag }}</option>
-    {% endfor %}
+  {% endfor %}
   </select>
 </div>
 
@@ -38,3 +38,4 @@ Here’s a list of my posts:
     </div>
   {% endfor %}
 </div>
+<p id="no-posts" class="no-posts hidden">No posts found.</p>

--- a/scripts/new_post.py
+++ b/scripts/new_post.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Create a new blog post file with front matter."""
+import os
+import re
+from datetime import datetime
+
+POSTS_DIR = '_posts'
+
+
+def slugify(title: str) -> str:
+    slug = title.lower()
+    slug = re.sub(r'[^a-z0-9]+', '-', slug)
+    slug = slug.strip('-')
+    return slug or 'post'
+
+
+def main():
+    title = input('Title: ').strip()
+    if not title:
+        print('Title is required.')
+        return
+
+    date_input = input('Date [leave blank for now]: ').strip()
+    if date_input:
+        try:
+            dt = datetime.fromisoformat(date_input)
+        except ValueError:
+            print('Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS')
+            return
+    else:
+        dt = datetime.utcnow()
+
+    date_str = dt.strftime('%Y-%m-%d %H:%M:%S +0000')
+
+    tags_input = input('Tags (comma separated): ').strip()
+    tags = [t.strip() for t in tags_input.split(',') if t.strip()]
+
+    slug = slugify(title)
+    filename = f"{dt.strftime('%Y-%m-%d')}-{slug}.md"
+    path = os.path.join(POSTS_DIR, filename)
+
+    if os.path.exists(path):
+        print(f"File {filename} already exists.")
+        return
+
+    with open(path, 'w') as f:
+        f.write('---\n')
+        f.write('layout: post\n')
+        f.write(f'title: "{title}"\n')
+        f.write(f'date:  {date_str}\n')
+        f.write('tags:\n')
+        for tag in tags:
+            f.write(f'  - {tag}\n')
+        f.write('---\n\n')
+
+    print(f'Created {path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `scripts/new_post.py` to generate post files with front matter
- document new publishing workflow in `docs/usage.md`
- mention helper script in README
- show a "No posts found" message when filtering posts
- tweak CSS for filters and add `.no-posts` style

## Testing
- `python3 tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_68409627e1488325ac6ca6042d20d925