### PR TITLE
Improve post card styles on main page

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -208,29 +208,30 @@ article + article {
 }
 
 .post-cards {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
 }
 
 .post-card {
   display: flex;
   align-items: center;
+  gap: 1rem;
   padding: 1rem;
   background: var(--card-bg);
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: box-shadow 0.2s, transform 0.2s;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.3s, transform 0.2s;
 }
 
 .post-card:hover {
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-4px);
 }
 
 .post-card .material-icons {
-  font-size: 2rem;
-  margin-right: 1rem;
+  font-size: 2.25rem;
   color: var(--link-color);
 }
 
@@ -241,6 +242,12 @@ article + article {
 
 .post-card a:hover {
   text-decoration: underline;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 500;
 }
 
 .card-date {
@@ -454,6 +461,9 @@ body.dark .hljs-comment {
 }
 
 @media (max-width: 480px) {
+  .post-cards {
+    grid-template-columns: 1fr;
+  }
   .post-card {
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- restyle post cards with grid layout and updated hover effects
- tweak icon size and add card title styling
- adjust responsive layout for mobile screens

## Testing
- `python tests/test_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_68409976f0f083258acb70d00dc8b9c4